### PR TITLE
chore: add bower.json

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -1,0 +1,17 @@
+{
+  "name": "to-id",
+  "description": "Normalises strings for comparison or usage as IDs",
+  "main": "to-id.js",
+  "authors": [
+    "Gregor Martynus <gregor@martynus.net>"
+  ],
+  "license": "MIT",
+  "homepage": "http://gr2m.github.io/to-id",
+  "ignore": [
+    "**/.*",
+    "node_modules",
+    "bower_components",
+    "test",
+    "tests"
+  ]
+}


### PR DESCRIPTION
Hey! The README promises that the library can be installed via `bower` but it's missing a `bower.json` so I think that's probably not possible, yet? ;-)